### PR TITLE
configure tailwind to use  montserrat font

### DIFF
--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -1,3 +1,8 @@
+/* header font*/
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
+/* body font*/
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -6,8 +6,12 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-      'larva-pink': '#FF04B4',
+        'larva-pink': '#FF04B4',
       },
+    },
+    fontFamily: {
+      sans: ['Montserrat', 'sans-serif'],
+      heading: ['Montserrat', 'sans-serif'],
     },
   },
   plugins: [],


### PR DESCRIPTION
Desktop Screen:
<img width="1675" alt="Screen Shot 2022-02-21 at 10 09 23 AM" src="https://user-images.githubusercontent.com/25194487/155007940-f6f5f276-09e8-4f2f-9fa8-8842c97be41d.png">

iphone SE:
<img width="464" alt="Screen Shot 2022-02-21 at 10 07 35 AM" src="https://user-images.githubusercontent.com/25194487/155007986-f75d210e-0c47-49ae-a2e7-c170e025d720.png">

